### PR TITLE
fix copyTemplate editor path

### DIFF
--- a/lib/copyTemplateAssets.js
+++ b/lib/copyTemplateAssets.js
@@ -41,7 +41,7 @@ const copyTemplateAssets = function ( stream ) {
 	} );
 	stream.push( editorCss );
 
-	let editorJsSrc = fs.readFileSync( __dirname + '/editor/build/_editor/_editor.Js', { encoding: 'utf-8' } );
+	let editorJsSrc = fs.readFileSync( __dirname + '/editor/build/_editor/_editor.js', { encoding: 'utf-8' } );
 	let editorJs = new File( {
 		path: '_editor/_editor.js',
 		contents: new Buffer( editorJsSrc )


### PR DESCRIPTION
This library is excellent !
But when I execute 'uimd' task on CircleCI, the following error occurred.
So I fixed this error.

```
(node:12436) fs: re-evaluating native module sources is not supported. If you are using the graceful-fs module, please update it to a more recent version.
[13:15:06] Using gulpfile ~/xxxx/gulpfile.js
[13:15:06] Starting 'uimd'...
[13:15:06] 'uimd' errored after 10 ms
[13:15:06] Error: ENOENT: no such file or directory, open '/home/ubuntu/xxxx/node_modules/ui-spec-md/lib/editor/build/_editor/_editor.Js'
    at Error (native)
    at Object.fs.openSync (fs.js:640:18)
    at Object.fs.readFileSync (fs.js:508:33)
    at copyTemplateAssets (/home/ubuntu/xxxx/node_modules/ui-spec-md/lib/copyTemplateAssets.js:44:23)
    ....
```
