### PR TITLE
Fix Editorへのパスのズレ

### DIFF
--- a/lib/template/build/_template.html
+++ b/lib/template/build/_template.html
@@ -36,7 +36,7 @@
 							<li><button class="UISP-Doc__screenButton" data-UISP-tool="highlight">highlight</button></li>
 						</ul>
 						<ul>
-							<li><button class="UISP-Doc__screenButton" data-UISP-tool="editor">Edit</button></li>
+							<li><a class="UISP-Doc__screenButton" data-UISP-tool="editor" href="<%= toRoot %>_editor.html">Edit</a></li>
 						</ul>
 					</div>
 					<div class="UISP-Doc__screenMain">

--- a/lib/template/build/_template/_template.js
+++ b/lib/template/build/_template/_template.js
@@ -160,9 +160,11 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	} );
 
 
-	document.querySelector( 'button[data-UISP-tool="editor"]').addEventListener( 'click', function () {
+	document.querySelector( 'a[data-UISP-tool="editor"]').addEventListener( 'click', function ( e ) {
 
-		window.open( `./_editor.html?src=${ captureSrc }`, 'EDT-Editor' );
+		var baseUrl = e.target.getAttribute('href');
+		e.preventDefault();
+		window.open( baseUrl + `?src=${ captureSrc }`, 'EDT-Editor' );
 
 	} );
 

--- a/lib/template/src/_template.html
+++ b/lib/template/src/_template.html
@@ -36,7 +36,7 @@
 							<li><button class="UISP-Doc__screenButton" data-UISP-tool="highlight">highlight</button></li>
 						</ul>
 						<ul>
-							<li><button class="UISP-Doc__screenButton" data-UISP-tool="editor">Edit</button></li>
+							<li><a class="UISP-Doc__screenButton" data-UISP-tool="editor" href="<%= toRoot %>_editor.html">Edit</a></li>
 						</ul>
 					</div>
 					<div class="UISP-Doc__screenMain">

--- a/lib/template/src/js/template.js
+++ b/lib/template/src/js/template.js
@@ -99,9 +99,11 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	} );
 
 
-	document.querySelector( 'button[data-UISP-tool="editor"]').addEventListener( 'click', function () {
+	document.querySelector( 'a[data-UISP-tool="editor"]').addEventListener( 'click', function ( e ) {
 
-		window.open( `./_editor.html?src=${ captureSrc }`, 'EDT-Editor' );
+		var baseUrl = e.target.getAttribute('href');
+		e.preventDefault();
+		window.open( baseUrl + `?src=${ captureSrc }`, 'EDT-Editor' );
 
 	} );
 


### PR DESCRIPTION
## 問題

ディレクトリが深いmdファイルに対して実行すると、（Editボタンの）Highlight Editorへのパスがずれる。
### 例

mdのパス: src/hoge/fuga.md の時、
生成されるHTMLは、 build/hoge/fuga.html 等になるので、 buildをrootとしてサーバーを建ててたら、 http://localhost:3000/hoge/fuga.html とかでアクセスできるが、Editボタンを押すと http://localhost:3000/hoge/_editor.html になっちゃう。
## 原因

https://github.com/pxgrid/ui-spec-md/blob/master/lib/template/src/js/template.js#L104 で相対パスにしてるから。
## 対応
1. Editorボタンをbutton要素からa要素に
2. Editorボタンにhref属性でHighlight Editorへのパスを指定
3. JSでEditorボタンをおした時の処理を以下に
   - event.preventDefault()
   - href属性値 + srcパラメータでwindow.open
