### PR TITLE
mdファイルの更新日と作成日の表示する機能を追加

### DIFF
--- a/lib/makePageHtml.js
+++ b/lib/makePageHtml.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const _            = require( 'lodash' );
-const fs           = require( 'fs' );
-const path         = require( 'path' );
-const sizeOf       = require( 'image-size' );
+const _      = require( 'lodash' );
+const fs     = require( 'fs' );
+const path   = require( 'path' );
+const sizeOf = require( 'image-size' );
 
 const makePageHtml = function ( contents ) {
 

--- a/lib/makePageHtml.js
+++ b/lib/makePageHtml.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const _      = require( 'lodash' );
-const fs     = require( 'fs' );
-const path   = require( 'path' );
-const sizeOf = require( 'image-size' );
+const _            = require( 'lodash' );
+const fs           = require( 'fs' );
+const path         = require( 'path' );
+const sizeOf       = require( 'image-size' );
 
 const makePageHtml = function ( contents ) {
 
@@ -11,10 +11,12 @@ const makePageHtml = function ( contents ) {
 	let template = _.template( templateSrc );
 
 	return template( {
-		toRoot   : contents.toRoot,
-		title    : contents.title,
-		svgCanvas: makeSvgCanvasSrc( contents.dir, contents.screen ),
-		body     : contents.body
+		toRoot       : contents.toRoot,
+		title        : contents.title,
+		svgCanvas    : makeSvgCanvasSrc( contents.dir, contents.screen ),
+		body         : contents.body,
+		modifiedDate : contents.modifiedDate,
+		createdDate  : contents.createdDate
 	} );
 
 }

--- a/lib/splitInput.js
+++ b/lib/splitInput.js
@@ -1,20 +1,25 @@
 'use strict';
 
+var fs   = require( 'fs' );
 var path = require( 'path' );
 var yaml = require( 'js-yaml' );
+var { DateTime } = require( 'luxon' );
 
 var splitInput = function ( file, rootDir ) {
 
 	var fileContents = new String( file.contents );
 	var dir = path.dirname( file.path );
+	var fileStat = fs.statSync( file.path.replace( /\.html$/, '.md' ) );
 	var result = {
-		title     : '',
-		screen    : '',
-		mdSource  : '',
-		filename  : path.basename( file.path.replace( /\.md$/, '.html' ) ),
-		dir       : dir.replace( /([^(.|/)]$)/, '$1/' ),
-		fromRoot  : path.relative( rootDir, dir ).replace( /([^(.|/)]$)/, '$1/' ),
-		toRoot    : path.relative( dir, rootDir ).replace( /([^/]$)/, '$1/' )
+		title        : '',
+		screen       : '',
+		mdSource     : '',
+		filename     : path.basename( file.path.replace( /\.md$/, '.html' ) ),
+		dir          : dir.replace( /([^(.|/)]$)/, '$1/' ),
+		fromRoot     : path.relative( rootDir, dir ).replace( /([^(.|/)]$)/, '$1/' ),
+		toRoot       : path.relative( dir, rootDir ).replace( /([^/]$)/, '$1/' ),
+		modifiedDate : DateTime.fromJSDate(fileStat.mtime).toFormat('yyyy/MM/dd HH:mm:ss'),
+		createdDate  : DateTime.fromJSDate(fileStat.birthtime).toFormat('yyyy/MM/dd HH:mm:ss')
 	}
 
 	var metaYaml;

--- a/lib/splitInput.js
+++ b/lib/splitInput.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var fs   = require( 'fs' );
-var path = require( 'path' );
-var yaml = require( 'js-yaml' );
+var fs           = require( 'fs' );
+var path         = require( 'path' );
+var yaml         = require( 'js-yaml' );
 var { DateTime } = require( 'luxon' );
 
 var splitInput = function ( file, rootDir ) {

--- a/lib/template/build/_template.html
+++ b/lib/template/build/_template.html
@@ -52,6 +52,14 @@
 					<div class="UISP-Md"><%= body %></div>
 
 				</div>
+				<div class="UISP-Doc__mdFileDate">
+					<div class="UISP-Doc__mdFileModifiedDate">
+						LastUpdate: <%= modifiedDate %>
+					</div>
+					<div class="UISP-Doc__mdFileCreatedDate">
+						Created: <%= createdDate %>
+					</div>
+				</div>
 			</div>
 		</div>
 		<% if ( !!svgCanvas ) { %><div class="UISP-Separator"></div><% } %>

--- a/lib/template/build/_template/_template.css
+++ b/lib/template/build/_template/_template.css
@@ -818,6 +818,22 @@ body {
 .UISP-Doc__mdContentInner {
   padding: 40px; }
 
+.UISP-Doc__mdFileDate {
+  font-size: 12px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+      -ms-flex-pack: end;
+          justify-content: flex-end;
+  padding: 10px 40px; }
+
+.UISP-Doc__mdFileModifiedDate,
+.UISP-Doc__mdFileCreatedDate {
+  padding-left: 20px; }
+
 /* ==========================================================================
 	 separator
 	 ========================================================================== */

--- a/lib/template/src/_template.html
+++ b/lib/template/src/_template.html
@@ -52,6 +52,14 @@
 					<div class="UISP-Md"><%= body %></div>
 
 				</div>
+				<div class="UISP-Doc__mdFileDate">
+					<div class="UISP-Doc__mdFileModifiedDate">
+						LastUpdate: <%= modifiedDate %>
+					</div>
+					<div class="UISP-Doc__mdFileCreatedDate">
+						Created: <%= createdDate %>
+					</div>
+				</div>
 			</div>
 		</div>
 		<% if ( !!svgCanvas ) { %><div class="UISP-Separator"></div><% } %>

--- a/lib/template/src/scss/_layout.scss
+++ b/lib/template/src/scss/_layout.scss
@@ -202,7 +202,17 @@ body {
 	.UISP-Doc__mdContentInner{
 		padding: 40px;
 	}
+.UISP-Doc__mdFileDate{
+	font-size: 12px;
+	display: flex;
+	justify-content: flex-end;
+	padding: 10px 40px;
+}
 
+.UISP-Doc__mdFileModifiedDate,
+.UISP-Doc__mdFileCreatedDate{
+	padding-left: 20px;
+}
 
 /* ==========================================================================
 	 separator

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "image-size": "^0.5.0",
     "js-yaml": "^3.5.5",
     "lodash": "^4.8.2",
+    "luxon": "^0.2.9",
     "marked": "^0.3.5",
     "natural-compare-lite": "^1.4.0",
     "vinyl": "^1.1.1",


### PR DESCRIPTION
refs #20

Specがいつ更新されたのか知りたいという要件があるため、機能追加のPRになります。
mdファイルのファイル情報から更新日と作成日を取り出してHTMLに埋め込むようにしました。
見た目は次のようになります。

<img width="1382" alt="lastupdate-created" src="https://user-images.githubusercontent.com/1369376/34159339-431e8174-e50c-11e7-8fc5-49ff147c7af9.png">
